### PR TITLE
global $config has been deprecated, using `docute.init(config)` instead

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-self.$config = {
+docute.init({
   title: 'Koel',
   repo: 'phanan/koel',
   twitter: 'notphanan',
@@ -18,4 +18,4 @@ self.$config = {
     { title: 'Use with Amazon S3', path: '/aws-s3' },
     { title: 'Troubleshooting', path: '/troubleshooting' }
   ]
-}
+})

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
   <!-- don't remove this part start -->
   <div id="app"></div>
   <script src="https://unpkg.com/docute@2/plugins/docsearch.js"></script>
-  <script src="./config.js"></script>
   <script src="https://unpkg.com/docute@2/dist/docute.js"></script>
+  <script src="./config.js"></script>
   <script>
   window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
   ga('create', 'UA-73152563-2', 'auto');


### PR DESCRIPTION
Upgraded to be compatible with changes in v2.10.0.

warning on JavaScript console:
> global $config has been deprecated, use `docute.init(config)` instead.
> See more at https://github.com/egoist/docute/releases/tag/v2.10.0


> self.$config is still supported but there will be a deprecation message, and self.$config will be removed in next major version which is v3.0