### PR TITLE
Add hyzual/koel docker image link

### DIFF
--- a/home.md
+++ b/home.md
@@ -44,7 +44,7 @@ If you want more control, edit `.env` file. There's quite a few settings there t
 
 ### With Docker
 
-Koel doesn't maintain an official Docker image, but community-supported ones like [hyzual/koel](https://hub.docker.com/r/hyzual/koel/), [0xcaff/koel](https://hub.docker.com/r/0xcaff/koel/) and [binhex/arch-koel](https://hub.docker.com/r/binhex/arch-koel/) are available.
+Koel doesn't maintain an official Docker image, but community-supported ones like [hyzual/koel](https://hub.docker.com/r/hyzual/koel/), [0xcaff/koel](https://hub.docker.com/r/0xcaff/koel/), and [binhex/arch-koel](https://hub.docker.com/r/binhex/arch-koel/) are available.
 
 ## Upgrade
 

--- a/home.md
+++ b/home.md
@@ -44,7 +44,7 @@ If you want more control, edit `.env` file. There's quite a few settings there t
 
 ### With Docker
 
-Koel doesn't maintain an official Docker image, but community-supported ones like [0xcaff/koel](https://hub.docker.com/r/0xcaff/koel/) and [binhex/arch-koel](https://hub.docker.com/r/binhex/arch-koel/) are available.
+Koel doesn't maintain an official Docker image, but community-supported ones like [hyzual/koel](https://hub.docker.com/r/hyzual/koel/), [0xcaff/koel](https://hub.docker.com/r/0xcaff/koel/) and [binhex/arch-koel](https://hub.docker.com/r/binhex/arch-koel/) are available.
 
 ## Upgrade
 


### PR DESCRIPTION
Hi,
First of all thanks for building koel ! 😄 It's a great player and I've been using it for more than a year.
I have tried contributing to [0xcaff/koel](https://github.com/0xcaff/docker-koel) a [couple of months ago](https://github.com/0xcaff/docker-koel/pull/20#issue-327565428) without response. Seeing as it looks like this image is no longer maintained, I forked it and published another docker image [hyzual/koel](https://hub.docker.com/r/hyzual/koel/).
Since I use koel a lot, I do plan on keeping it maintained.
I am opening this PR to add a link to my image in koel's documentation, to help people find a maintained Docker image.
Let me know if any change is needed.
Have a good day