### PR TITLE
Update Readme.md

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -63,7 +63,7 @@ If you want more control, edit `.env` file. There's quite a few settings there t
 
 ### Using Docker
 
-Koel has an official Docker image: [koel/docker](https://github.com/koel/docker). Communinity-supported images such as [0xcaff/koel](https://hub.docker.com/r/0xcaff/koel/) and [binhex/arch-koel](https://hub.docker.com/r/binhex/arch-koel/) are also available.
+Koel has an official Docker image: [koel/docker](https://github.com/koel/docker).
 
 ## Upgrade
 


### PR DESCRIPTION
The binhex repository either does not exist or has been removed and the 0xcaff repository was last updated 4 years ago. I think it would be advisable to remove them from the documentation.